### PR TITLE
Bump Newtonsoft.Json

### DIFF
--- a/DotNetWebClientOAuth2/Infor.OAuth2SampleWPFAuthCode/packages.config
+++ b/DotNetWebClientOAuth2/Infor.OAuth2SampleWPFAuthCode/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
   <package id="Thinktecture.IdentityModel.Client" version="4.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
### Description

This PR modifies the packages.config file in the DotNetWebClientOAuth2/Infor.OAuth2SampleWPFAuthCode directory. The only change made is the version number of the Newtonsoft.Json package. 

- The Newtonsoft.Json package version is changed from 6.0.5 to 13.0.1.
- No other changes were made in this PR.