### PR TITLE
Bump Microsoft.Owin.Security.Cookies

### DIFF
--- a/DotNetRichClientOAuth2/MvcCodeFlowClientManual/packages.config
+++ b/DotNetRichClientOAuth2/MvcCodeFlowClientManual/packages.config
@@ -13,7 +13,7 @@
   <package id="Microsoft.Owin" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="3.0.0" targetFramework="net45" />
-  <package id="Microsoft.Owin.Security.Cookies" version="3.0.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Security.Cookies" version="4.2.2" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Modernizr" version="2.8.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />


### PR DESCRIPTION
### Description

Updated the version of the "Microsoft.Owin.Security.Cookies" package from 3.0.0 to 4.2.2 in the packages.config file.