### PR TITLE
Bump junit from 3.8.1 to 4.13.1 in /JavaWebClientOAuth2

### DIFF
--- a/JavaWebClientOAuth2/pom.xml
+++ b/JavaWebClientOAuth2/pom.xml
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
 	<dependency>


### PR DESCRIPTION
### Description

This pull request modifies the `pom.xml` file of the `JavaWebClientOAuth2` project. 

The changes include:

- Updating the version of the `junit` dependency from `3.8.1` to `4.13.1`.
- No other changes were made in this pull request.