### PR TITLE
Bump jQuery in /DotNetRichClientOAuth2/MvcCodeFlowClientManual

### DIFF
--- a/DotNetRichClientOAuth2/MvcCodeFlowClientManual/packages.config
+++ b/DotNetRichClientOAuth2/MvcCodeFlowClientManual/packages.config
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net45" />
   <package id="bootstrap" version="3.4.1" targetFramework="net45" />
-  <package id="jQuery" version="2.1.1" targetFramework="net45" />
+  <package id="jQuery" version="3.5.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />


### PR DESCRIPTION
Bumps jQuery from 2.1.1 to 3.5.0.

---
updated-dependencies:
- dependency-name: jQuery dependency-type: direct:production ...

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
