### PR TITLE
Bump Newtonsoft.Json

### DIFF
--- a/DotNetWebClientOAuth2/Infor.OAuth2SampleConsoleResourceOwner/packages.config
+++ b/DotNetWebClientOAuth2/Infor.OAuth2SampleConsoleResourceOwner/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
   <package id="Thinktecture.IdentityModel.Client" version="4.0.1" targetFramework="net45" />
   <package id="Thinktecture.IdentityModel.Core" version="1.4.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
### Description

This pull request modifies the packages.config file in the DotNetWebClientOAuth2/Infor.OAuth2SampleConsoleResourceOwner project. The primary change is the version number of the "Newtonsoft.Json" package, which has been updated from 6.0.5 to 13.0.1 to ensure compatibility with the latest version of the package and any dependencies it may have.
        
Additionally, there are no other changes made to the packages.config file in this pull request.

Changes:
- Updated the version of the "Newtonsoft.Json" package to 13.0.1